### PR TITLE
Format db/install.xml

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <XMLDB PATH="blocks/course_template" VERSION="20120508" COMMENT="XMLDB file for Moodle course template block"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+    xsi:noNamespaceSchemaLocation="../../lib/xmldb/xmldb.xsd"
 >
   <TABLES>
-    <TABLE NAME="block_course_template" COMMENT="Table for course template block" NEXT="block_course_template_tag">
+    <TABLE NAME="block_course_template" COMMENT="Table for course template block">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="filename"/>
-        <FIELD NAME="filename" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" PREVIOUS="id" NEXT="name"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="filename" NEXT="description"/>
-        <FIELD NAME="description" TYPE="text" LENGTH="big" NOTNULL="false" SEQUENCE="false" PREVIOUS="name" NEXT="course"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="description" NEXT="screenshot"/>
-        <FIELD NAME="screenshot" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false" PREVIOUS="course" NEXT="timecreated"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="screenshot" NEXT="timemodified"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="timecreated" />
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="filename" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="screenshot" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="course"/>
-        <KEY NAME="course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id" PREVIOUS="primary" />
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="course" TYPE="foreign" FIELDS="course" REFTABLE="course" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="block_course_template_tag" COMMENT="Table for course template module" PREVIOUS="block_course_template" NEXT="block_course_template_tag_in">
+    <TABLE NAME="block_course_template_tag" COMMENT="Table for course template module">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="name"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="id" NEXT="timemodified"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="name" />
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" />
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
     </TABLE>
-    <TABLE NAME="block_course_template_tag_in" COMMENT="Table for course template module" PREVIOUS="block_course_template_tag">
+    <TABLE NAME="block_course_template_tag_in" COMMENT="Table for course template module">
       <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" UNSIGNED="true" SEQUENCE="true" NEXT="tag"/>
-        <FIELD NAME="tag" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="id" NEXT="template" />
-        <FIELD NAME="template" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="tag" NEXT="timemodified" />
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" PREVIOUS="template" />
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="tag" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="template" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
       </FIELDS>
       <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" NEXT="tag" />
-        <KEY NAME="tag" TYPE="foreign" FIELDS="tag" REFTABLE="block_course_template_tag" REFFIELDS="id" PREVIOUS="primary" NEXT="template"  />
-        <KEY NAME="template" TYPE="foreign" FIELDS="template" REFTABLE="block_course_template" REFFIELDS="id" PREVIOUS="tag" />
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="tag" TYPE="foreign" FIELDS="tag" REFTABLE="block_course_template_tag" REFFIELDS="id"/>
+        <KEY NAME="template" TYPE="foreign" FIELDS="template" REFTABLE="block_course_template" REFFIELDS="id"/>
       </KEYS>
     </TABLE>
   </TABLES>


### PR DESCRIPTION
- Totara 10 is very picky


Getting more unit test failures on T10:

`ubuntu@mining-box:/var/www/siteroot$ ./vendor/bin/phpunit --stop-on-failure --testsuite tool_xmldb_testsuite
Totara 10.1 (Build: 20171027.00), 2bc01781ba5f2836b17f0fb5c9ac2e3a29ac3770
PHP: 7.0.22.0.0.16.04.1, pgsql: 9.5.9, OS: Linux 4.4.0-98-generic x86_64
PHPUnit 5.7.23 by Sebastian Bergmann and contributors.

F                                                                   1 / 1 (100%)

Time: 4.56 seconds, Memory: 32.00MB

There was 1 failure:

1) tool_xmldb_instal_xml_testcase::test_all_install_xml_files_formatted_correctly
XMLDB file '/var/www/siteroot/blocks/course_template/db/install.xml' is different to the generated version, please edit the file in XMLDB editor and save it.
Failed asserting that false is true.

/var/www/siteroot/admin/tool/xmldb/tests/install_xml_test.php:52
/var/www/siteroot/lib/phpunit/classes/base_testcase.php:600
/var/www/siteroot/lib/phpunit/classes/advanced_testcase.php:68

To re-run:
 vendor/bin/phpunit tool_xmldb_instal_xml_testcase admin/tool/xmldb/tests/install_xml_test.php

FAILURES!
Tests: 1, Assertions: 78, Failures: 1.
` 